### PR TITLE
test_client: add lunr_api_endpoint to LunrClient initialization

### DIFF
--- a/testlunrdriver/unit/lunr/test_client.py
+++ b/testlunrdriver/unit/lunr/test_client.py
@@ -20,6 +20,7 @@ from StringIO import StringIO
 import json
 
 from lunrdriver.lunr import client
+from lunrdriver.lunr.flags import CONF
 
 
 class MockResponse(object):
@@ -110,7 +111,7 @@ class TestLunrClient(unittest.TestCase):
         client.urlopen = self._orig_urlopen
 
     def test_get_volume(self):
-        c = client.LunrClient({'project_id': 'fake'})
+        c = client.LunrClient(CONF.lunr_api_endpoint, {'project_id': 'fake'})
         def volume_get(req):
             self.assertEquals(req.get_method(), 'GET')
             expected_path = 'http://127.0.0.1:8080/v1.0/fake/volumes/volid?'
@@ -123,7 +124,7 @@ class TestLunrClient(unittest.TestCase):
         self.assertEquals(resp.body['account_id'], 'fake')
 
     def test_get_volume_error(self):
-        c = client.LunrClient({'project_id': 'fake'})
+        c = client.LunrClient(CONF.lunr_api_endpoint, {'project_id': 'fake'})
         def url_error(req):
             raise stub_error(req, reason='connection refused')
         self.set_response(url_error)
@@ -140,7 +141,7 @@ class TestLunrClient(unittest.TestCase):
         self.assert_(http_error.called)
 
     def test_export_delete(self):
-        c = client.LunrClient({'project_id': 'fake'})
+        c = client.LunrClient(CONF.lunr_api_endpoint, {'project_id': 'fake'})
         def export_delete(req):
             self.assertEquals(req.get_method(), 'DELETE')
             expected_path = 'http://127.0.0.1:8080/v1.0/fake/volumes/' + \
@@ -152,7 +153,7 @@ class TestLunrClient(unittest.TestCase):
         self.assert_(export_delete.called)
 
     def test_export_delete_force(self):
-        c = client.LunrClient({'project_id': 'fake'})
+        c = client.LunrClient(CONF.lunr_api_endpoint, {'project_id': 'fake'})
         def export_delete_force(req):
             self.assertEquals(req.get_method(), 'DELETE')
             expected_path = 'http://127.0.0.1:8080/v1.0/fake/volumes/' + \


### PR DESCRIPTION
The `LunrClient.__init__` signature was changed in c4e77dd21cbe8616db19614e6fdd5ff5f52e7aae:

``` diff
 class LunrClient(object):

-    def __init__(self, context, logger=None):
+    def __init__(self, url, context, logger=None):
         """
```

It looks like this test was never updated accordingly.
