### PR TITLE
python3 compatibility

### DIFF
--- a/lunrdriver/driver/__init__.py
+++ b/lunrdriver/driver/__init__.py
@@ -1,1 +1,1 @@
-from driver import LunrDriver
+from lunrdriver.driver.driver import LunrDriver

--- a/lunrdriver/driver/driver.py
+++ b/lunrdriver/driver/driver.py
@@ -20,7 +20,7 @@ except ImportError:
     from cinder.openstack.common import log as logging
 
 from lunrdriver.lunr.client import LunrClient, LunrError
-from utils import initialize_connection
+from lunrdriver.driver.utils import initialize_connection
 
 
 lunr_opts = [

--- a/lunrdriver/driver/driver.py
+++ b/lunrdriver/driver/driver.py
@@ -172,7 +172,7 @@ class LunrDriver(VolumeDriver):
             client = LunrClient(self.url, volume, logger=LOG)
             volume_id = self._lookup_volume_id(volume)
             client.volumes.delete(volume_id)
-        except LunrError, e:
+        except LunrError as e:
             # ignore Not Found on delete
             if e.code != 404:
                 raise
@@ -210,7 +210,7 @@ class LunrDriver(VolumeDriver):
             client.backups.delete(snapshot['id'])
             client.backups.wait_on_status(snapshot['id'],
                                           'DELETED', 'AUDITING')
-        except LunrError, e:
+        except LunrError as e:
             # ignore Not Found on delete_snapshot. Don't wait on status.
             if e.code == 404:
                 return

--- a/lunrdriver/lunr/api.py
+++ b/lunrdriver/lunr/api.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 
+from six import string_types
+
 from cinder.volume.api import API as CinderAPI
 try:
     from cinder.i18n import _
@@ -44,7 +46,7 @@ class API(CinderAPI):
     def _is_lunr_volume_type(self, context, volume_type):
         if not volume_type:
             return False
-        if isinstance(volume_type, basestring):
+        if isinstance(volume_type, string_types):
             volume_type = self.db.volume_type_get(context, volume_type)
         return volume_type['name'] in CONF.lunr_volume_types
 

--- a/lunrdriver/lunr/api.py
+++ b/lunrdriver/lunr/api.py
@@ -57,7 +57,7 @@ class API(CinderAPI):
             client = LunrClient(CONF.lunr_api_endpoint,
                                 lunr_context, logger=LOG)
             resp = client.types.get(volume_type['name'])
-        except LunrError, e:
+        except LunrError as e:
             LOG.error(_('unable to fetch volume type from LunR: %s'),
                       volume_type)
             raise

--- a/lunrdriver/lunr/auth.py
+++ b/lunrdriver/lunr/auth.py
@@ -85,13 +85,13 @@ class RackAuth(object):
             try:
                 resp = urlopen(req)
                 return json.loads(resp.read())
-            except HTTPError, e:
+            except HTTPError as e:
                 if e.code == 401:
                     self._admin_token = None
                 elif e.code == 404 and self._admin_token:
                     # 404 means invalid token, no retry
                     raise
-            except Exception, e:
+            except Exception as e:
                 pass
             if attempt >= attempts:
                 raise
@@ -127,7 +127,7 @@ class RackAuth(object):
         path = '/v2.0/tokens/%s?belongsTo=%s' % (token, account)
         try:
             token_info = self._auth_request(path)
-        except HTTPError, e:
+        except HTTPError as e:
             if e.code == 404:
                 raise InvalidUserToken('token not found')
             else:
@@ -174,7 +174,7 @@ class RackAuth(object):
         try:
             LOG.debug('Validate token')
             token_info = self.get_token_info(token, account)
-        except InvalidUserToken, e:
+        except InvalidUserToken as e:
             LOG.info('Invalid token (%s)' % e)
             return HTTPUnauthorized()(environ, start_response)
         except Exception:

--- a/lunrdriver/lunr/auth.py
+++ b/lunrdriver/lunr/auth.py
@@ -16,7 +16,8 @@
 
 import json
 import time
-import urllib2
+from six.moves.urllib.request import Request, urlopen
+from six.moves.urllib.error import HTTPError
 from webob.exc import HTTPUnauthorized, HTTPServiceUnavailable
 
 try:
@@ -79,12 +80,12 @@ class RackAuth(object):
                 headers['X-Auth-Token'] = self.admin_token
             req_path = self.admin_url + path
             LOG.debug('req_path: %s - headers: %s' % (req_path, headers))
-            req = urllib2.Request(req_path, headers=headers, data=body)
+            req = Request(req_path, headers=headers, data=body)
             req.get_method = lambda *args: method
             try:
-                resp = urllib2.urlopen(req)
+                resp = urlopen(req)
                 return json.loads(resp.read())
-            except urllib2.HTTPError, e:
+            except HTTPError, e:
                 if e.code == 401:
                     self._admin_token = None
                 elif e.code == 404 and self._admin_token:
@@ -126,7 +127,7 @@ class RackAuth(object):
         path = '/v2.0/tokens/%s?belongsTo=%s' % (token, account)
         try:
             token_info = self._auth_request(path)
-        except urllib2.HTTPError, e:
+        except HTTPError, e:
             if e.code == 404:
                 raise InvalidUserToken('token not found')
             else:

--- a/lunrdriver/lunr/client.py
+++ b/lunrdriver/lunr/client.py
@@ -219,5 +219,5 @@ class LunrClient(object):
             self.logger.debug("%s on %s succeeded with %s" %
                 (req.get_method(), req.get_full_url(), resp.getcode()))
             return resp
-        except (HTTPError, URLError, HTTPException), e:
+        except (HTTPError, URLError, HTTPException) as e:
             raise LunrError(req, e)

--- a/lunrdriver/lunr/client.py
+++ b/lunrdriver/lunr/client.py
@@ -1,10 +1,10 @@
 import json
 import socket
-import urllib2
 
-from httplib import HTTPException, BadStatusLine
-from urllib import urlencode
-from urllib2 import Request, urlopen, URLError, HTTPError
+from six.moves.http_client import HTTPException, BadStatusLine
+from six.moves.urllib.parse import urlencode
+from six.moves.urllib.request import Request, urlopen
+from six.moves.urllib.error import URLError, HTTPError
 from webob import exc
 
 try:
@@ -119,7 +119,7 @@ class LunrTypeResource(LunrResource):
 
 class LunrError(Exception):
     # Catch IOError to handle uncaught SSL Errors
-    exceptions = (urllib2.URLError, HTTPException, urllib2.HTTPError, IOError)
+    exceptions = (URLError, HTTPException, HTTPError, IOError)
 
     title = exc.HTTPServiceUnavailable.title
     code = exc.HTTPServiceUnavailable.code
@@ -134,7 +134,7 @@ class LunrError(Exception):
             self.detail += "failed with socket timeout"
             self.reason = self.detail
 
-        if type(e) is urllib2.HTTPError:
+        if type(e) is HTTPError:
             raw_body = ''.join(e.fp.read())
             self.reason = raw_body  # most basic reason
             try:
@@ -151,7 +151,7 @@ class LunrError(Exception):
             self.title = e.msg
             self.code = e.code
 
-        if type(e) is urllib2.URLError:
+        if type(e) is URLError:
             self.detail += "failed with '%s'" % e.reason
             self.reason = e.reason
 

--- a/lunrdriver/lunr/client.py
+++ b/lunrdriver/lunr/client.py
@@ -130,11 +130,11 @@ class LunrError(Exception):
         self.url = req.get_full_url()
         self.detail = "%s on %s " % (self.method, self.url)
 
-        if type(e) is socket.timeout:
+        if isinstance(e, socket.timeout):
             self.detail += "failed with socket timeout"
             self.reason = self.detail
 
-        if type(e) is HTTPError:
+        if isinstance(e, HTTPError):
             raw_body = ''.join(e.fp.read())
             self.reason = raw_body  # most basic reason
             try:
@@ -151,11 +151,11 @@ class LunrError(Exception):
             self.title = e.msg
             self.code = e.code
 
-        if type(e) is URLError:
+        if isinstance(e, URLError):
             self.detail += "failed with '%s'" % e.reason
             self.reason = e.reason
 
-        if type(e) is IOError:
+        if isinstance(e, IOError):
             self.detail += "failed with '%s'" % e
             self.reason = str(e)
 

--- a/lunrdriver/lunr/lunrrpc.py
+++ b/lunrdriver/lunr/lunrrpc.py
@@ -123,7 +123,7 @@ class LunrRPC(object):
         try:
             resp = LunrClient(volume, logger=LOG).volumes.create(
                 volume['id'], **params)
-        except LunrError, e:
+        except LunrError as e:
             LOG.debug('error creating volume %s', volume['id'])
             # Don't leave an error'd volume around, the raise here
             # will notify the caller of the error (See Github Issue #343)
@@ -155,7 +155,7 @@ class LunrRPC(object):
         volume = db.volume_get(context, volume_id)
         try:
             LunrClient(volume, logger=LOG).volumes.delete(volume['id'])
-        except LunrError, e:
+        except LunrError as e:
             # ignore Not Found on delete
             if e.code == 404:
                 LOG.debug(_("volume %s: already deleted"),
@@ -196,7 +196,7 @@ class LunrRPC(object):
         }
         try:
             client.backups.create(snapshot['id'], **params)
-        except LunrError, e:
+        except LunrError as e:
             LOG.debug(_('error creating snapshot %s'), snapshot_id)
             # Don't leave an error'd snapshot around, the raise here
             # will notify the caller of the error (See Github Issue #322)
@@ -230,7 +230,7 @@ class LunrRPC(object):
         client = LunrClient(snapshot, logger=LOG)
         try:
             client.backups.delete(snapshot['id'])
-        except LunrError, e:
+        except LunrError as e:
             # ignore Not Found on delete_snapshot. Don't wait on status.
             if e.code == 404:
                 db.snapshot_destroy(context, snapshot['id'])

--- a/lunrdriver/lunr/utils.py
+++ b/lunrdriver/lunr/utils.py
@@ -16,7 +16,7 @@
 
 import socket
 
-from client import LunrClient
+from lunrdriver.lunr.client import LunrClient
 
 
 def resolve_hostname(target_portal):
@@ -67,4 +67,3 @@ def attach_volume(client, volume_id, instance_id, mountpoint):
 
 def detach_volume(client, volume_id):
     client.exports.update(volume_id, instance_id=None)
-

--- a/testlunrdriver/unit/driver/__init__.py
+++ b/testlunrdriver/unit/driver/__init__.py
@@ -1,7 +1,7 @@
 import unittest
 
-import __builtin__
-setattr(__builtin__, '_', lambda x: x)
+from six.moves import builtins
+setattr(builtins, '_', lambda x: x)
 
 from six.moves import StringIO
 from cgi import parse_qsl

--- a/testlunrdriver/unit/driver/__init__.py
+++ b/testlunrdriver/unit/driver/__init__.py
@@ -1,5 +1,6 @@
 import unittest
 
+from six import string_types
 from six.moves import builtins
 setattr(builtins, '_', lambda x: x)
 
@@ -59,7 +60,7 @@ class ClientTestCase(unittest.TestCase):
     @resp.setter
     def resp(self, resp=''):
         """Set next resp from urlopen"""
-        if isinstance(resp, basestring) or isinstance(resp, Exception):
+        if isinstance(resp, string_types) or isinstance(resp, Exception):
             resp = [resp]
         self._resp = (r for r in resp)
 

--- a/testlunrdriver/unit/driver/__init__.py
+++ b/testlunrdriver/unit/driver/__init__.py
@@ -3,7 +3,7 @@ import unittest
 import __builtin__
 setattr(__builtin__, '_', lambda x: x)
 
-from StringIO import StringIO
+from six.moves import StringIO
 from cgi import parse_qsl
 from contextlib import contextmanager
 

--- a/testlunrdriver/unit/driver/__init__.py
+++ b/testlunrdriver/unit/driver/__init__.py
@@ -47,7 +47,7 @@ class ClientTestCase(unittest.TestCase):
     def resp(self):
         """Get test provided next resp for ulropen, and clear next resp"""
         try:
-            resp = self._resp.next()
+            resp = next(self._resp)
             return resp
         except AttributeError:
             return ''

--- a/testlunrdriver/unit/driver/test_driver.py
+++ b/testlunrdriver/unit/driver/test_driver.py
@@ -76,24 +76,24 @@ class TestLunrDriver(DriverTestCase):
 
     def test_create_driver_instance(self):
         d = driver.LunrDriver(configuration=self.configuration)
-        self.assertEquals(d.url, d.configuration.lunr_api_endpoint)
+        self.assertEqual(d.url, d.configuration.lunr_api_endpoint)
 
     def test_create_volume(self):
         volume = {'name': 'vol1', 'size': 1, 'project_id': 100,
                   'id': '123-456', 'volume_type': {'name': 'vtype'}}
         def callback(req):
-            self.assertEquals(req.get_method(), 'PUT')
+            self.assertEqual(req.get_method(), 'PUT')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/100/volumes/%s' % volume['id'])
+            self.assertEqual(url.path, '/v1.0/100/volumes/%s' % volume['id'])
             data = urldecode(url.query)
-            self.assertEquals(data['size'], '1')
-            self.assertEquals(data['volume_type_name'], 'vtype')
+            self.assertEqual(data['size'], '1')
+            self.assertEqual(data['volume_type_name'], 'vtype')
         self.request_callback = callback
         self.resp = [json.dumps({'size': 1, 'cinder_host': 'foo'})]
         d = driver.LunrDriver(configuration=self.configuration)
         update = d.create_volume(volume)
-        self.assert_(self.request_callback.called)
-        self.assertEquals(update['host'], 'foo')
+        self.assertTrue(self.request_callback.called)
+        self.assertEqual(update['host'], 'foo')
 
     def test_create_volume_duplicate(self):
         volume = {'name': 'vol1', 'size': 1, 'project_id': 100,
@@ -102,15 +102,15 @@ class TestLunrDriver(DriverTestCase):
         def callback(req):
             # First call gets the 409
             if len(self.request_callback.called) == 1:
-                self.assertEquals(req.get_method(), 'PUT')
+                self.assertEqual(req.get_method(), 'PUT')
                 url = urlparse(req.get_full_url())
-                self.assertEquals(url.path, '/v1.0/100/volumes/%s' % volume['id'])
+                self.assertEqual(url.path, '/v1.0/100/volumes/%s' % volume['id'])
                 return
             # We need to capture the lunr_id from the retry
-            self.assertEquals(req.get_method(), 'PUT')
+            self.assertEqual(req.get_method(), 'PUT')
             url = urlparse(req.get_full_url())
             data = urldecode(url.query)
-            self.assertEquals(data['name'], '123-456')
+            self.assertEqual(data['name'], '123-456')
             # Lazy way to find the new id
             lunr_id.append(url.path[1+url.path.rfind('/'):])
         self.request_callback = callback
@@ -120,9 +120,9 @@ class TestLunrDriver(DriverTestCase):
         self.resp = [err, json.dumps({'size': 1, 'cinder_host': 'foo'})]
         d = driver.LunrDriver(configuration=self.configuration)
         update = d.create_volume(volume)
-        self.assertEquals(len(self.request_callback.called), 2)
-        self.assertEquals(1, len(lunr_id))
-        self.assertEquals(update['_name_id'], lunr_id[0])
+        self.assertEqual(len(self.request_callback.called), 2)
+        self.assertEqual(1, len(lunr_id))
+        self.assertEqual(update['_name_id'], lunr_id[0])
 
     def test_create_volume_with_meta(self):
         MetaEntry = namedtuple('MetaEntry', ['key', 'value'])
@@ -131,20 +131,20 @@ class TestLunrDriver(DriverTestCase):
                   'id': '123-456', 'volume_type': {'name': 'vtype'},
                   'volume_metadata': [meta]}
         def callback(req):
-            self.assertEquals(req.get_method(), 'PUT')
+            self.assertEqual(req.get_method(), 'PUT')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/100/volumes/%s' % volume['id'])
+            self.assertEqual(url.path, '/v1.0/100/volumes/%s' % volume['id'])
             data = urldecode(url.query)
-            self.assertEquals(data['size'], '1')
-            self.assertEquals(data['volume_type_name'], 'vtype')
+            self.assertEqual(data['size'], '1')
+            self.assertEqual(data['volume_type_name'], 'vtype')
         self.request_callback = callback
         self.resp = [json.dumps({'size': 1, 'cinder_host': 'foo',
                                  'node_id': 'nodeuuid'})]
         d = driver.LunrDriver(configuration=self.configuration)
         update = d.create_volume(volume)
-        self.assert_(self.request_callback.called)
-        self.assertEquals(update['host'], 'foo')
-        self.assertEquals(update['metadata'], {'foo': 'bar',
+        self.assertTrue(self.request_callback.called)
+        self.assertEqual(update['host'], 'foo')
+        self.assertEqual(update['metadata'], {'foo': 'bar',
                                                'storage-node': 'nodeuuid'})
 
     def test_create_volume_with_affinity(self):
@@ -154,21 +154,21 @@ class TestLunrDriver(DriverTestCase):
                   'id': '123-456', 'volume_type': {'name': 'vtype'},
                   'volume_metadata': [meta]}
         def callback(req):
-            self.assertEquals(req.get_method(), 'PUT')
+            self.assertEqual(req.get_method(), 'PUT')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/100/volumes/%s' % volume['id'])
+            self.assertEqual(url.path, '/v1.0/100/volumes/%s' % volume['id'])
             data = urldecode(url.query)
-            self.assertEquals(data['size'], '1')
-            self.assertEquals(data['affinity'], 'different_node:foo,bar,baz')
-            self.assertEquals(data['volume_type_name'], 'vtype')
+            self.assertEqual(data['size'], '1')
+            self.assertEqual(data['affinity'], 'different_node:foo,bar,baz')
+            self.assertEqual(data['volume_type_name'], 'vtype')
         self.request_callback = callback
         self.resp = [json.dumps({'size': 1, 'cinder_host': 'foo',
                                  'node_id': 'nodeuuid'})]
         d = driver.LunrDriver(configuration=self.configuration)
         update = d.create_volume(volume)
-        self.assert_(self.request_callback.called)
-        self.assertEquals(update['host'], 'foo')
-        self.assertEquals(update['metadata'], {'different_node': 'foo,bar,baz',
+        self.assertTrue(self.request_callback.called)
+        self.assertEqual(update['host'], 'foo')
+        self.assertEqual(update['metadata'], {'different_node': 'foo,bar,baz',
                                                'storage-node': 'nodeuuid'})
 
     def test_create_volume_with_maintenance_zone(self):
@@ -178,21 +178,21 @@ class TestLunrDriver(DriverTestCase):
                   'id': '123-456', 'volume_type': {'name': 'vtype'},
                   'volume_metadata': [meta]}
         def callback(req):
-            self.assertEquals(req.get_method(), 'PUT')
+            self.assertEqual(req.get_method(), 'PUT')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/100/volumes/%s' % volume['id'])
+            self.assertEqual(url.path, '/v1.0/100/volumes/%s' % volume['id'])
             data = urldecode(url.query)
-            self.assertEquals(data['size'], '1')
-            self.assertEquals(data['zone'], 'foobar')
-            self.assertEquals(data['volume_type_name'], 'vtype')
+            self.assertEqual(data['size'], '1')
+            self.assertEqual(data['zone'], 'foobar')
+            self.assertEqual(data['volume_type_name'], 'vtype')
         self.request_callback = callback
         self.resp = [json.dumps({'size': 1, 'cinder_host': 'foo',
                                  'node_id': 'nodeuuid'})]
         d = driver.LunrDriver(configuration=self.configuration)
         update = d.create_volume(volume)
-        self.assert_(self.request_callback.called)
-        self.assertEquals(update['host'], 'foo')
-        self.assertEquals(update['metadata'], {'maintenance_zone': 'foobar',
+        self.assertTrue(self.request_callback.called)
+        self.assertEqual(update['host'], 'foo')
+        self.assertEqual(update['metadata'], {'maintenance_zone': 'foobar',
                                                'storage-node': 'nodeuuid'})
 
     def test_create_volume_from_snapshot(self):
@@ -201,14 +201,14 @@ class TestLunrDriver(DriverTestCase):
         snapshot = {'name': 'backup1', 'id': '456-789'}
         def callback(req):
             if len(self.request_callback.called) > 1:
-                self.assertEquals(req.get_method(), 'GET')
+                self.assertEqual(req.get_method(), 'GET')
                 return
-            self.assertEquals(req.get_method(), 'PUT')
+            self.assertEqual(req.get_method(), 'PUT')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/100/volumes/%s' % '123-456')
+            self.assertEqual(url.path, '/v1.0/100/volumes/%s' % '123-456')
             data = urldecode(url.query)
-            self.assertEquals(data['volume_type_name'], 'vtype')
-            self.assertEquals(data['backup'], snapshot['id'])
+            self.assertEqual(data['volume_type_name'], 'vtype')
+            self.assertEqual(data['backup'], snapshot['id'])
         self.request_callback = callback
         building_status = json.dumps({
             'status': 'BUILDING',
@@ -221,8 +221,8 @@ class TestLunrDriver(DriverTestCase):
         d = driver.LunrDriver(configuration=self.configuration)
         with patch(client, 'sleep', no_sleep):
             update = d.create_volume_from_snapshot(volume, snapshot)
-        self.assertEquals(len(self.request_callback.called), 3)
-        self.assertEquals(update, {'size': 1, 'host': 'foo'})
+        self.assertEqual(len(self.request_callback.called), 3)
+        self.assertEqual(update, {'size': 1, 'host': 'foo'})
 
     def test_create_cloned_volume(self):
         volume = {'name': 'vol1', 'size': 5, 'project_id': 100,
@@ -231,14 +231,14 @@ class TestLunrDriver(DriverTestCase):
                   'id': '234-567', 'volume_type': {'name': 'vtype'}}
         def callback(req):
             if len(self.request_callback.called) > 1:
-                self.assertEquals(req.get_method(), 'GET')
+                self.assertEqual(req.get_method(), 'GET')
                 return
-            self.assertEquals(req.get_method(), 'PUT')
+            self.assertEqual(req.get_method(), 'PUT')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/100/volumes/%s' % volume['id'])
+            self.assertEqual(url.path, '/v1.0/100/volumes/%s' % volume['id'])
             data = urldecode(url.query)
-            self.assertEquals(data['volume_type_name'], 'vtype')
-            self.assertEquals(data['source_volume'], '234-567')
+            self.assertEqual(data['volume_type_name'], 'vtype')
+            self.assertEqual(data['source_volume'], '234-567')
         self.request_callback = callback
         building_status = json.dumps({
             'status': 'BUILDING',
@@ -250,7 +250,7 @@ class TestLunrDriver(DriverTestCase):
         d = driver.LunrDriver(configuration=self.configuration)
         with patch(client, 'sleep', no_sleep):
             d.create_cloned_volume(volume, source)
-        self.assertEquals(len(self.request_callback.called), 3)
+        self.assertEqual(len(self.request_callback.called), 3)
 
     def test_clone_image(self):
         volume = {'name': 'vol1', 'size': 5, 'project_id': 100,
@@ -259,13 +259,13 @@ class TestLunrDriver(DriverTestCase):
         image_meta = {'id': 'image_id_1'}
         def callback(req):
             if len(self.request_callback.called) > 1:
-                self.assertEquals(req.get_method(), 'GET')
+                self.assertEqual(req.get_method(), 'GET')
                 return
-            self.assertEquals(req.get_method(), 'PUT')
+            self.assertEqual(req.get_method(), 'PUT')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/100/volumes/%s' % volume['id'])
+            self.assertEqual(url.path, '/v1.0/100/volumes/%s' % volume['id'])
             data = urldecode(url.query)
-            self.assertEquals(data['image_id'], image_meta['id'])
+            self.assertEqual(data['image_id'], image_meta['id'])
         self.request_callback = callback
         building_status = json.dumps({
             'status': 'BUILDING',
@@ -278,7 +278,7 @@ class TestLunrDriver(DriverTestCase):
         with patch(client, 'sleep', no_sleep):
             d.clone_image('unused', volume, image_location, image_meta,
                           'image_service')
-        self.assertEquals(len(self.request_callback.called), 3)
+        self.assertEqual(len(self.request_callback.called), 3)
 
     def test_failed_volume_create(self):
         # TODO: resp should be URLError'y
@@ -287,20 +287,20 @@ class TestLunrDriver(DriverTestCase):
         volume = {'name': 'vol1', 'size': 1, 'project_id': 100,
                   'id': '234-567', 'volume_type': {'name': 'vtype'}}
         self.assertRaises(Exception, d.create_volume, volume)
-        self.assert_(self.request_callback.called)
+        self.assertTrue(self.request_callback.called)
 
     def test_delete_volume(self):
         volume = {'name': 'vol1', 'size': 1, 'project_id': 100,
                   'id': '345-678', 'volume_type': {'name': 'vtype'}}
         def callback(req):
-            self.assertEquals(req.get_method(), 'DELETE')
+            self.assertEqual(req.get_method(), 'DELETE')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/100/volumes/%s' % volume['id'])
+            self.assertEqual(url.path, '/v1.0/100/volumes/%s' % volume['id'])
         self.request_callback = callback
         self.resp = [json.dumps({'status': 'DELETING'})]
         d = driver.LunrDriver(configuration=self.configuration)
         d.delete_volume(volume)
-        self.assert_(self.request_callback.called)
+        self.assertTrue(self.request_callback.called)
 
     def test_failed_delete_connection_error(self):
         self.resp = URLError(OSError(errno.ECONNREFUSED,
@@ -309,7 +309,7 @@ class TestLunrDriver(DriverTestCase):
         volume = {'name': 'vol1', 'size': 1, 'project_id': 100,
                   'id': '456-789', 'volume_type': {'name': 'vtype'}}
         self.assertRaises(client.LunrError, d.delete_volume, volume)
-        self.assert_(self.request_callback.called)
+        self.assertTrue(self.request_callback.called)
 
     def test_failed_delete_server_error(self):
         # url, code, msg, hdrs, fp
@@ -319,7 +319,7 @@ class TestLunrDriver(DriverTestCase):
         volume = {'name': 'vol1', 'size': 1, 'project_id': 100,
                   'id': '456-789', 'volume_type': {'name': 'vtype'}}
         self.assertRaises(client.LunrError, d.delete_volume, volume)
-        self.assert_(self.request_callback.called)
+        self.assertTrue(self.request_callback.called)
 
     def test_success_delete_not_found(self):
         # url, code, msg, hdrs, fp
@@ -329,7 +329,7 @@ class TestLunrDriver(DriverTestCase):
         volume = {'name': 'vol1', 'size': 1, 'project_id': 100,
                   'id': '456-789', 'volume_type': {'name': 'vtype'}}
         d.delete_volume(volume)
-        self.assert_(self.request_callback.called)
+        self.assertTrue(self.request_callback.called)
 
     def test_success_delete_snapshot_not_found(self):
         # url, code, msg, hdrs, fp
@@ -338,7 +338,7 @@ class TestLunrDriver(DriverTestCase):
         d = driver.LunrDriver(configuration=self.configuration)
         snapshot = {'project_id': 100, 'id': 's456-789'}
         d.delete_snapshot(snapshot)
-        self.assert_(self.request_callback.called)
+        self.assertTrue(self.request_callback.called)
 
     def test_initialize_connection(self):
         volume = {'id': 1, 'name': 'vol1', 'project_id': 'dev'}
@@ -348,9 +348,9 @@ class TestLunrDriver(DriverTestCase):
             'target_name': 'iqn-vol1',
         })
         def callback(req):
-            self.assertEquals(req.get_method(), 'PUT')
+            self.assertEqual(req.get_method(), 'PUT')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path,
+            self.assertEqual(url.path,
                               '/v1.0/dev/volumes/%s/export' % volume['id'])
         self.request_callback = callback
         d = driver.LunrDriver(configuration=self.configuration)
@@ -360,7 +360,7 @@ class TestLunrDriver(DriverTestCase):
             connection_info = d.initialize_connection(volume, self.connector)
         finally:
             utils.socket.gethostbyname = _orig_gethostbyname
-        self.assert_(self.request_callback.called)
+        self.assertTrue(self.request_callback.called)
         expected = {
             'driver_volume_type': 'iscsi',
             'data': {
@@ -370,7 +370,7 @@ class TestLunrDriver(DriverTestCase):
                 'volume_id': 1,
             }
         }
-        self.assertEquals(connection_info, expected)
+        self.assertEqual(connection_info, expected)
 
     def test_target_portal_is_ip(self):
         volume = {'id': 1, 'name': 'vol1', 'project_id': 'dev'}
@@ -380,9 +380,9 @@ class TestLunrDriver(DriverTestCase):
             'target_name': 'iqn-vol1',
         })
         def callback(req):
-            self.assertEquals(req.get_method(), 'PUT')
+            self.assertEqual(req.get_method(), 'PUT')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path,
+            self.assertEqual(url.path,
                               '/v1.0/dev/volumes/%s/export' % volume['id'])
         self.request_callback = callback
         d = driver.LunrDriver(configuration=self.configuration)
@@ -394,7 +394,7 @@ class TestLunrDriver(DriverTestCase):
             connection_info = d.initialize_connection(volume, self.connector)
         finally:
             utils.socket.gethostbyname = _orig_gethostbyname
-        self.assert_(self.request_callback.called)
+        self.assertTrue(self.request_callback.called)
         expected = {
             'driver_volume_type': 'iscsi',
             'data': {
@@ -404,7 +404,7 @@ class TestLunrDriver(DriverTestCase):
                 'volume_id': 1,
             }
         }
-        self.assertEquals(connection_info, expected)
+        self.assertEqual(connection_info, expected)
 
     def test_gethostbyname_lookup_fails(self):
         volume = {'id': 1, 'name': 'vol1', 'project_id': 'dev'}
@@ -415,9 +415,9 @@ class TestLunrDriver(DriverTestCase):
             'target_name': 'iqn-vol1',
         })
         def callback(req):
-            self.assertEquals(req.get_method(), 'PUT')
+            self.assertEqual(req.get_method(), 'PUT')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path,
+            self.assertEqual(url.path,
                               '/v1.0/dev/volumes/%s/export' % volume['id'])
         self.request_callback = callback
         d = driver.LunrDriver(configuration=self.configuration)
@@ -429,7 +429,7 @@ class TestLunrDriver(DriverTestCase):
             connection_info = d.initialize_connection(volume, self.connector)
         finally:
             utils.socket.gethostbyname = _orig_gethostbyname
-        self.assert_(self.request_callback.called)
+        self.assertTrue(self.request_callback.called)
         expected = {
             'driver_volume_type': 'iscsi',
             'data': {
@@ -439,7 +439,7 @@ class TestLunrDriver(DriverTestCase):
                 'volume_id': 1,
             }
         }
-        self.assertEquals(connection_info, expected)
+        self.assertEqual(connection_info, expected)
 
     def test_create_snapshot_success(self):
         # args
@@ -470,21 +470,21 @@ class TestLunrDriver(DriverTestCase):
 
         # setup request verification stack
         def create_callback(req):
-            self.assertEquals(req.get_method(), 'PUT')
+            self.assertEqual(req.get_method(), 'PUT')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/dev/backups/0000-0000')
+            self.assertEqual(url.path, '/v1.0/dev/backups/0000-0000')
             data = urldecode(url.query)
-            self.assertEquals(data['volume_id'], '0000-0001')
+            self.assertEqual(data['volume_id'], '0000-0001')
 
         def saving_callback(req):
-            self.assertEquals(req.get_method(), 'GET')
+            self.assertEqual(req.get_method(), 'GET')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/dev/backups/0000-0000')
+            self.assertEqual(url.path, '/v1.0/dev/backups/0000-0000')
 
         def ready_callback(req):
-            self.assertEquals(req.get_method(), 'GET')
+            self.assertEqual(req.get_method(), 'GET')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/dev/backups/0000-0000')
+            self.assertEqual(url.path, '/v1.0/dev/backups/0000-0000')
 
         callbacks = [create_callback, saving_callback, ready_callback]
         def request_callback(req):
@@ -499,7 +499,7 @@ class TestLunrDriver(DriverTestCase):
         d.db = MockDB()
         with patch(client, 'sleep', no_sleep):
             d.create_snapshot(snapshot)
-        self.assertEquals(len(self.request_callback.called), 3)
+        self.assertEqual(len(self.request_callback.called), 3)
 
     def test_create_snapshot_errors(self):
         # args
@@ -530,21 +530,21 @@ class TestLunrDriver(DriverTestCase):
 
         # setup request verification stack
         def create_callback(req):
-            self.assertEquals(req.get_method(), 'PUT')
+            self.assertEqual(req.get_method(), 'PUT')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/dev/backups/0000-0000')
+            self.assertEqual(url.path, '/v1.0/dev/backups/0000-0000')
             data = urldecode(url.query)
-            self.assertEquals(data['volume_id'], '0000-0001')
+            self.assertEqual(data['volume_id'], '0000-0001')
 
         def saving_callback(req):
-            self.assertEquals(req.get_method(), 'GET')
+            self.assertEqual(req.get_method(), 'GET')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/dev/backups/0000-0000')
+            self.assertEqual(url.path, '/v1.0/dev/backups/0000-0000')
 
         def ready_callback(req):
-            self.assertEquals(req.get_method(), 'GET')
+            self.assertEqual(req.get_method(), 'GET')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/dev/backups/0000-0000')
+            self.assertEqual(url.path, '/v1.0/dev/backups/0000-0000')
 
         callbacks = [create_callback, saving_callback, ready_callback]
         def request_callback(req):
@@ -559,7 +559,7 @@ class TestLunrDriver(DriverTestCase):
         d.db = MockDB()
         with patch(client, 'sleep', no_sleep):
             self.assertRaises(client.StatusError, d.create_snapshot, snapshot)
-        self.assertEquals(len(self.request_callback.called), 3)
+        self.assertEqual(len(self.request_callback.called), 3)
 
     def test_delete_snapshot_success(self):
         # args
@@ -592,11 +592,11 @@ class TestLunrDriver(DriverTestCase):
 
         # setup request verification stack
         def delete_callback(req):
-            self.assertEquals(req.get_method(), 'DELETE')
+            self.assertEqual(req.get_method(), 'DELETE')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/dev/backups/0000-0000')
+            self.assertEqual(url.path, '/v1.0/dev/backups/0000-0000')
             data = urldecode(url.query)
-            self.assertEquals(data['volume_id'], '0000-0001')
+            self.assertEqual(data['volume_id'], '0000-0001')
 
         callbacks = [delete_callback]
         def request_callback(req):
@@ -606,7 +606,7 @@ class TestLunrDriver(DriverTestCase):
         d = driver.LunrDriver(configuration=self.configuration)
         with patch(client, 'sleep', no_sleep):
             d.delete_snapshot(snapshot)
-        self.assertEquals(len(self.request_callback.called), 3)
+        self.assertEqual(len(self.request_callback.called), 3)
 
     def test_check_for_setup_error(self):
         # setup mock response
@@ -629,9 +629,9 @@ class TestLunrDriver(DriverTestCase):
         self.resp = [json.dumps([vtype1, vtype2])]
         # setup verify request callback
         def request_callback(req):
-            self.assertEquals(req.get_method(), 'GET')
+            self.assertEqual(req.get_method(), 'GET')
             url = urlparse(req.get_full_url())
-            self.assertEquals(url.path, '/v1.0/admin/volume_types')
+            self.assertEqual(url.path, '/v1.0/admin/volume_types')
         self.request_callback = request_callback
         d = driver.LunrDriver(configuration=self.configuration)
         # mock cinder db call
@@ -647,8 +647,8 @@ class TestLunrDriver(DriverTestCase):
 
         with patch(driver, 'volume_types', mock_volume_type_api):
             d.check_for_setup_error()
-        self.assert_(self.request_callback.called)
-        self.assert_(mock_volume_type_api.types, ['vtype1'])
+        self.assertTrue(self.request_callback.called)
+        self.assertTrue(mock_volume_type_api.types, ['vtype1'])
 
     def test_volume_type_already_exists(self):
         # setup mock response
@@ -688,16 +688,16 @@ class TestLunrDriver(DriverTestCase):
         d = driver.LunrDriver(configuration=self.configuration)
         with patch(driver, 'volume_types', mock_volume_type_api):
             d.check_for_setup_error()
-            self.assert_(self.request_callback.called)
-            self.assert_(mock_volume_type_api.types, ['vtype1', 'vtype2'])
-            self.assert_(mock_volume_type_api.duplicate_create_types, ['vtype1'])
+            self.assertTrue(self.request_callback.called)
+            self.assertTrue(mock_volume_type_api.types, ['vtype1', 'vtype2'])
+            self.assertTrue(mock_volume_type_api.duplicate_create_types, ['vtype1'])
             # call again
             self.resp = json.dumps([vtype1, vtype2])
             d.check_for_setup_error()
-            self.assert_(mock_volume_type_api.types, ['vtype1', 'vtype2'])
+            self.assertTrue(mock_volume_type_api.types, ['vtype1', 'vtype2'])
             expected = ['vtype1',  # from first run
                        'vtype1', 'vtype2']  # second time both raise
-            self.assert_(mock_volume_type_api.duplicate_create_types, expected)
+            self.assertTrue(mock_volume_type_api.duplicate_create_types, expected)
 
     def test_check_for_setup_error_fails(self):
         d = driver.LunrDriver(configuration=self.configuration)
@@ -724,7 +724,7 @@ class TestLunrDriver(DriverTestCase):
         self.resp = [err, err, json.dumps([vtype])]
         with patch(driver, 'sleep', no_sleep):
             d.check_for_setup_error()
-            self.assert_('new_type' in self.volume_types.store)
+            self.assertTrue('new_type' in self.volume_types.store)
 
 
 if __name__ == "__main__":

--- a/testlunrdriver/unit/driver/test_driver.py
+++ b/testlunrdriver/unit/driver/test_driver.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
-import __builtin__
-setattr(__builtin__, '_', lambda x: x)
+from six.moves import builtins
+setattr(builtins, '_', lambda x: x)
 
 import unittest
 from collections import namedtuple

--- a/testlunrdriver/unit/driver/test_driver.py
+++ b/testlunrdriver/unit/driver/test_driver.py
@@ -9,8 +9,8 @@ from datetime import datetime, timedelta
 import os
 import errno
 from StringIO import StringIO
-from urlparse import urlparse
-from urllib2 import HTTPError, URLError
+from six.moves.urllib.parse import urlparse
+from six.moves.urllib.error import URLError, HTTPError
 from cinder.exception import VolumeTypeNotFoundByName
 from cinder.volume import configuration as conf
 import json
@@ -706,7 +706,7 @@ class TestLunrDriver(DriverTestCase):
             OSError(
                 errno.ECONNREFUSED, os.strerror(errno.ECONNREFUSED)
             )
-        ) 
+        )
         self.resp = [err for i in range(3)]
         with patch(driver, 'sleep', no_sleep):
             d.check_for_setup_error()

--- a/testlunrdriver/unit/driver/test_driver.py
+++ b/testlunrdriver/unit/driver/test_driver.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from datetime import datetime, timedelta
 import os
 import errno
-from StringIO import StringIO
+from six.moves import StringIO
 from six.moves.urllib.parse import urlparse
 from six.moves.urllib.error import URLError, HTTPError
 from cinder.exception import VolumeTypeNotFoundByName

--- a/testlunrdriver/unit/lunr/test_client.py
+++ b/testlunrdriver/unit/lunr/test_client.py
@@ -112,15 +112,15 @@ class TestLunrClient(unittest.TestCase):
     def test_get_volume(self):
         c = client.LunrClient({'project_id': 'fake'})
         def volume_get(req):
-            self.assertEquals(req.get_method(), 'GET')
+            self.assertEqual(req.get_method(), 'GET')
             expected_path = 'http://127.0.0.1:8080/v1.0/fake/volumes/volid?'
-            self.assertEquals(req.get_full_url(), expected_path)
+            self.assertEqual(req.get_full_url(), expected_path)
             return MockResponse(stub_volume(account_id='fake', id='volid'))
         self.set_response(volume_get)
         resp = c.volumes.get('volid')
-        self.assert_(volume_get.called)
-        self.assertEquals(resp.body['id'], 'volid')
-        self.assertEquals(resp.body['account_id'], 'fake')
+        self.assertTrue(volume_get.called)
+        self.assertEqual(resp.body['id'], 'volid')
+        self.assertEqual(resp.body['account_id'], 'fake')
 
     def test_get_volume_error(self):
         c = client.LunrClient({'project_id': 'fake'})
@@ -129,39 +129,39 @@ class TestLunrClient(unittest.TestCase):
         self.set_response(url_error)
         with self.assertRaises(client.LunrError) as manager:
             c.volumes.get('volid')
-            self.assertEquals(manager.exception.code, 0)
-        self.assert_(url_error.called)
+            self.assertEqual(manager.exception.code, 0)
+        self.assertTrue(url_error.called)
         def http_error(req):
             raise stub_error(req, 503)
         self.set_response(http_error)
         with self.assertRaises(client.LunrError) as manager:
             c.volumes.get('volid')
-            self.assertEquals(manager.exception.code, 503)
-        self.assert_(http_error.called)
+            self.assertEqual(manager.exception.code, 503)
+        self.assertTrue(http_error.called)
 
     def test_export_delete(self):
         c = client.LunrClient({'project_id': 'fake'})
         def export_delete(req):
-            self.assertEquals(req.get_method(), 'DELETE')
+            self.assertEqual(req.get_method(), 'DELETE')
             expected_path = 'http://127.0.0.1:8080/v1.0/fake/volumes/' + \
                     'volid/export?'
-            self.assertEquals(req.get_full_url(), expected_path)
+            self.assertEqual(req.get_full_url(), expected_path)
             return MockResponse()
         self.set_response(export_delete)
         resp = c.exports.delete('volid')
-        self.assert_(export_delete.called)
+        self.assertTrue(export_delete.called)
 
     def test_export_delete_force(self):
         c = client.LunrClient({'project_id': 'fake'})
         def export_delete_force(req):
-            self.assertEquals(req.get_method(), 'DELETE')
+            self.assertEqual(req.get_method(), 'DELETE')
             expected_path = 'http://127.0.0.1:8080/v1.0/fake/volumes/' + \
                     'volid/export?force=True'
-            self.assertEquals(req.get_full_url(), expected_path)
+            self.assertEqual(req.get_full_url(), expected_path)
             return MockResponse()
         self.set_response(export_delete_force)
         resp = c.exports.delete('volid', force=True)
-        self.assert_(export_delete_force.called)
+        self.assertTrue(export_delete_force.called)
 
 
 if __name__ == "__main__":

--- a/testlunrdriver/unit/lunr/test_client.py
+++ b/testlunrdriver/unit/lunr/test_client.py
@@ -15,7 +15,7 @@
 
 
 import unittest
-from urllib2 import URLError, HTTPError
+from six.moves.urllib.error import URLError, HTTPError
 from StringIO import StringIO
 import json
 

--- a/testlunrdriver/unit/lunr/test_client.py
+++ b/testlunrdriver/unit/lunr/test_client.py
@@ -57,7 +57,7 @@ class MockUrlOpen(object):
     def get_next_resp(self):
         if not self._resp_iter:
             self._resp_iter = iter(self._responses)
-        return self._resp_iter.next()
+        return next(self._resp_iter)
 
     def __call__(self, req, *args, **kwargs):
         resp = self.get_next_resp()

--- a/testlunrdriver/unit/lunr/test_client.py
+++ b/testlunrdriver/unit/lunr/test_client.py
@@ -16,7 +16,7 @@
 
 import unittest
 from six.moves.urllib.error import URLError, HTTPError
-from StringIO import StringIO
+from six.moves import StringIO
 import json
 
 from lunrdriver.lunr import client


### PR DESCRIPTION
This fixes several python3 compatibility issues, and breaks compatibility with python<=2.5.

Aside from #14, all tests pass in python2.7 and python3.5.

I broke up the changes in to hopefully digestible groups, but I'd be happy to squash if desired.
