### PR TITLE
CBS-566 - Products using identity v1.1 API need to migrate to v2.0 

### DIFF
--- a/lunrdriver/lunr/flags.py
+++ b/lunrdriver/lunr/flags.py
@@ -16,9 +16,10 @@
 
 try:
     from oslo_config import cfg
+    from oslo_config.cfg import DuplicateOptError
 except ImportError:
     from oslo.config import cfg
-
+    from oslo.config.cfg import DuplicateOptError
 
 lunr_opts = [
     cfg.StrOpt('lunr_api_endpoint', default='http://127.0.0.1:8080/v1.0',
@@ -39,11 +40,16 @@ CONF.register_opts(lunr_opts)
 # authtoken middleware
 keystone_authtoken_opts = [
     cfg.StrOpt('auth_uri',
-               default=None,
+               default='http://127.0.0.1:5000/v2.0/',
                # FIXME(dolph): should be default='http://127.0.0.1:5000/v2.0/',
                # or (depending on client support) an unversioned, publicly
                # accessible identity endpoint (see bug 1207517)
                help='Complete public Identity API endpoint.'),
 ]
 
-CONF.register_opts(keystone_authtoken_opts, group='keystone_authtoken')
+try:
+    # When loading V2 Cinder API this registration happens twice causing
+    # DuplicateOptError , here we are simply ignoring the exception
+    CONF.register_opts(keystone_authtoken_opts, group='keystone_authtoken')
+except DuplicateOptError as e:
+    pass

--- a/lunrdriver/lunr/flags.py
+++ b/lunrdriver/lunr/flags.py
@@ -35,21 +35,3 @@ lunr_opts = [
 CONF = cfg.CONF
 CONF.register_opts(lunr_opts)
 
-
-# This is a dirty hack for working around liberty requiring keystone
-# authtoken middleware
-keystone_authtoken_opts = [
-    cfg.StrOpt('auth_uri',
-               default='http://127.0.0.1:5000/v2.0/',
-               # FIXME(dolph): should be default='http://127.0.0.1:5000/v2.0/',
-               # or (depending on client support) an unversioned, publicly
-               # accessible identity endpoint (see bug 1207517)
-               help='Complete public Identity API endpoint.'),
-]
-
-try:
-    # When loading V2 Cinder API this registration happens twice causing
-    # DuplicateOptError , here we are simply ignoring the exception
-    CONF.register_opts(keystone_authtoken_opts, group='keystone_authtoken')
-except DuplicateOptError as e:
-    pass


### PR DESCRIPTION
JIRA url: https://jira.rax.io/browse/CBS-566
changes done were removing dependency on Idenityv1.1 , adding default url for keystone middleware.